### PR TITLE
Allow returning `anyway::Result` from run functions

### DIFF
--- a/src/template/part1.rs
+++ b/src/template/part1.rs
@@ -1,3 +1,5 @@
-pub fn run(input: &str) -> usize {
-    input.parse::<usize>().unwrap() * 2
+use anyhow::Result;
+
+pub fn run(input: &str) -> Result<usize> {
+    Ok(input.parse::<usize>()? * 2)
 }

--- a/src/template/part2.rs
+++ b/src/template/part2.rs
@@ -1,3 +1,5 @@
-pub fn run(input: &str) -> usize {
-    input.parse::<usize>().unwrap() * 3
+use anyhow::Result;
+
+pub fn run(input: &str) -> Result<usize> {
+    Ok(input.parse::<usize>()? * 3)
 }

--- a/src/y2022/star01/part1.rs
+++ b/src/y2022/star01/part1.rs
@@ -1,4 +1,6 @@
-pub fn run(input: &str) -> usize {
+use anyhow::Result;
+
+pub fn run(input: &str) -> Result<usize> {
     let mut best = 0;
     let mut current = 0;
     for line in input.lines() {
@@ -8,8 +10,8 @@ pub fn run(input: &str) -> usize {
             }
             current = 0;
         } else {
-            current += line.parse::<usize>().unwrap();
+            current += line.parse::<usize>()?;
         }
     }
-    std::cmp::max(best, current)
+    Ok(std::cmp::max(best, current))
 }

--- a/src/y2022/star01/part2.rs
+++ b/src/y2022/star01/part2.rs
@@ -1,4 +1,6 @@
-pub fn run(input: &str) -> usize {
+use anyhow::Result;
+
+pub fn run(input: &str) -> Result<usize> {
     let mut values = Vec::new();
     let mut current = 0;
     for line in input.lines() {
@@ -6,10 +8,10 @@ pub fn run(input: &str) -> usize {
             values.push(current);
             current = 0;
         } else {
-            current += line.parse::<usize>().unwrap();
+            current += line.parse::<usize>()?;
         }
     }
     values.push(current);
     values.sort_unstable();
-    values.iter().rev().take(3).sum()
+    Ok(values.iter().rev().take(3).sum())
 }

--- a/src/y2022/star02/part1.rs
+++ b/src/y2022/star02/part1.rs
@@ -115,7 +115,7 @@ impl Round {
     }
 }
 
-fn run_safe(input: &str) -> Result<usize> {
+pub fn run(input: &str) -> Result<usize> {
     Ok(input
         .lines()
         .map(str::parse::<Round>)
@@ -123,8 +123,4 @@ fn run_safe(input: &str) -> Result<usize> {
         .into_iter()
         .map(Round::score)
         .sum::<usize>())
-}
-
-pub fn run(input: &str) -> usize {
-    run_safe(input).unwrap()
 }

--- a/src/y2022/star02/part2.rs
+++ b/src/y2022/star02/part2.rs
@@ -129,7 +129,7 @@ impl Round {
     }
 }
 
-fn run_safe(input: &str) -> Result<usize> {
+pub fn run(input: &str) -> Result<usize> {
     Ok(input
         .lines()
         .map(str::parse::<Round>)
@@ -137,8 +137,4 @@ fn run_safe(input: &str) -> Result<usize> {
         .into_iter()
         .map(Round::score)
         .sum())
-}
-
-pub fn run(input: &str) -> usize {
-    run_safe(input).unwrap()
 }

--- a/src/y2022/star03/part1.rs
+++ b/src/y2022/star03/part1.rs
@@ -41,7 +41,7 @@ impl Rucksack {
     }
 }
 
-fn run_safe(input: &str) -> Result<usize> {
+pub fn run(input: &str) -> Result<usize> {
     Ok(input
         .lines()
         .map(str::parse::<Rucksack>)
@@ -49,8 +49,4 @@ fn run_safe(input: &str) -> Result<usize> {
         .iter()
         .map(Rucksack::priority)
         .sum())
-}
-
-pub fn run(input: &str) -> usize {
-    run_safe(input).unwrap()
 }

--- a/src/y2022/star03/part2.rs
+++ b/src/y2022/star03/part2.rs
@@ -39,7 +39,7 @@ impl Group {
     }
 }
 
-fn run_safe(input: &str) -> Result<usize> {
+pub fn run(input: &str) -> Result<usize> {
     Ok(input
         .lines()
         .chunks(3)
@@ -49,8 +49,4 @@ fn run_safe(input: &str) -> Result<usize> {
         .iter()
         .map(Group::priority)
         .sum())
-}
-
-pub fn run(input: &str) -> usize {
-    run_safe(input).unwrap()
 }


### PR DESCRIPTION
Inspired by https://github.com/diwic/inner-rs
I needed generic impls, so I had to re-implement it, due to orphan rule

Later we can add checks for unwraps. This allows but Result and non-Result variants to work